### PR TITLE
fix: move runtime dependencies from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.6",
-    "@inkjs/ui": "^2.0.0",
     "@types/bun": "^1.2.18",
     "@types/marked-terminal": "^6.1.1",
     "@types/react": "^19.1.8",
@@ -71,7 +70,6 @@
     "knip": "^5.61.3",
     "lefthook": "^1.11.14",
     "publint": "^0.3.12",
-    "ts-pattern": "^5.5.0",
     "tsdown": "^0.12.9",
     "typescript": "^5.7.2",
     "vitest": "^3.2.4"
@@ -80,6 +78,7 @@
     "vite": "npm:rolldown-vite@latest"
   },
   "dependencies": {
+    "@inkjs/ui": "^2.0.0",
     "clipboardy": "^4.0.0",
     "commander": "^14.0.0",
     "fdir": "^6.4.6",
@@ -91,6 +90,7 @@
     "open": "^10.1.2",
     "open-editor": "^5.1.0",
     "react": "^19.1.0",
+    "ts-pattern": "^5.5.0",
     "zod": "^3.25.76"
   }
 }


### PR DESCRIPTION
## Overview

This PR fixes the placement of runtime dependencies that were incorrectly placed in devDependencies.

## Changes

### As-is
- `@inkjs/ui` and `ts-pattern` were in devDependencies
- When users install ccexp globally with `npm install -g ccexp`, these packages would not be installed
- This would cause runtime errors when users try to run the CLI

### To-be
- Moved `@inkjs/ui` and `ts-pattern` to dependencies
- These packages will now be properly installed when users install ccexp globally
- All runtime dependencies are correctly placed in the dependencies section

## Why this change is needed

ccexp is a CLI tool (not a library) that users install globally. When installed via `npm install -g ccexp`, only packages in the `dependencies` section are installed. Any packages required at runtime must be in dependencies, not devDependencies.