### PR TITLE
fix: update biome schema URL to match installed version

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.1/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## Overview

- Update schema URL from 2.0.6 to 2.1.1 to match the installed Biome version
- Resolves schema version mismatch warnings

related #26 