### PR TITLE
fix: improve long filename truncation in file list

### DIFF
--- a/src/components/FileList/FileItem.test.tsx
+++ b/src/components/FileList/FileItem.test.tsx
@@ -1,5 +1,5 @@
 import { render } from 'ink-testing-library';
-import type { ClaudeFileInfo } from '../../_types.js';
+import type { ClaudeFileInfo, ClaudeFileType } from '../../_types.js';
 import { createClaudeFilePath } from '../../_types.js';
 import { FileItem } from './FileItem.js';
 
@@ -85,6 +85,84 @@ if (import.meta.vitest) {
 
       expect(lastFrame()).toContain('test/CLAUDE.md');
       expect(lastFrame()).toContain('► '); // focus prefix
+    });
+
+    // Helper to create file info for long filename tests
+    const createFileInfo = (
+      basePath: string,
+      relativePath: string,
+      type: ClaudeFileType,
+    ): ClaudeFileInfo => ({
+      path: createClaudeFilePath(`${basePath}/${relativePath}`),
+      type,
+      size: 100,
+      lastModified: new Date('2024-01-01'),
+      commands: [],
+      tags: [],
+    });
+
+    test('should truncate very long file names properly', () => {
+      // 非常に長いファイル名を持つテストケース
+      const longFileName =
+        'this-is-a-very-very-very-very-very-very-very-very-very-very-long-filename-that-should-be-truncated-properly-without-breaking-the-layout.md';
+      const file = createFileInfo(
+        '/Users/test/projects',
+        longFileName,
+        'claude-md',
+      );
+      const { lastFrame } = render(
+        <FileItem file={file} isSelected={false} isFocused={false} />,
+      );
+
+      // ファイル名が含まれていることを確認（切り詰められていても）
+      expect(lastFrame()).toContain('projects/');
+      // バッジが正しく表示されることを確認
+      expect(lastFrame()).toContain('PROJECT');
+
+      // Check that the output doesn't overflow (it should be on a single line)
+      const lines = lastFrame()?.split('\n') || [];
+      const itemLine = lines.find((line) => line.includes('projects/'));
+      expect(itemLine).toBeDefined();
+    });
+
+    test('should handle very long directory paths', () => {
+      // 非常に長いディレクトリパスを持つテストケース
+      const file = createFileInfo(
+        '/Users/test/very/deep/nested/directory/structure/with/many/levels/that/go/on/and/on/and/on',
+        'CLAUDE.md',
+        'claude-md',
+      );
+      const { lastFrame } = render(
+        <FileItem file={file} isSelected={false} isFocused={false} />,
+      );
+
+      // ファイル名とバッジが表示されることを確認
+      expect(lastFrame()).toContain('CLAUDE.md');
+      expect(lastFrame()).toContain('PROJECT');
+
+      // Parent directory should be the last segment
+      expect(lastFrame()).toContain('on/CLAUDE.md');
+    });
+
+    test('should maintain layout with extremely long paths', () => {
+      // Create a path that's extremely long
+      const segments = Array(20).fill('very-long-directory-name');
+      const longPath = segments.join('/');
+      const file = createFileInfo(
+        `/Users/test/${longPath}`,
+        'CLAUDE.md',
+        'claude-md',
+      );
+
+      const { lastFrame } = render(
+        <FileItem file={file} isSelected={false} isFocused={false} />,
+      );
+
+      // Should still show the badge
+      expect(lastFrame()).toContain('PROJECT');
+
+      // Should contain the filename
+      expect(lastFrame()).toContain('CLAUDE.md');
     });
   });
 }

--- a/src/components/FileList/FileItem.tsx
+++ b/src/components/FileList/FileItem.tsx
@@ -95,31 +95,33 @@ export const FileItem = React.memo(function FileItem({
   const fileBadge = getFileBadge(file);
 
   return (
-    <Box justifyContent="space-between" width="100%">
-      <Box flexGrow={1} marginRight={1}>
-        {isSelected ? (
-          <Text
-            backgroundColor={theme.selection.backgroundColor}
-            color={theme.selection.color}
-            wrap="truncate-end"
-          >
-            {prefix}
-            {getFileIcon(file)} {displayName}
-          </Text>
-        ) : isFocused ? (
-          <Text color={theme.ui.focus} wrap="truncate-end">
-            {prefix}
-            {getFileIcon(file)} {displayName}
-          </Text>
-        ) : (
-          <Text wrap="truncate-end">
-            {prefix}
-            {getFileIcon(file)} {displayName}
-          </Text>
-        )}
-      </Box>
-      <Box flexShrink={0}>
-        <Badge color={fileBadge.color}>{fileBadge.label}</Badge>
+    <Box width="100%">
+      <Box flexDirection="row" gap={1}>
+        <Box flexGrow={1} flexShrink={1} minWidth={0}>
+          {isSelected ? (
+            <Text
+              backgroundColor={theme.selection.backgroundColor}
+              color={theme.selection.color}
+              wrap="truncate-end"
+            >
+              {prefix}
+              {getFileIcon(file)} {displayName}
+            </Text>
+          ) : isFocused ? (
+            <Text color={theme.ui.focus} wrap="truncate-end">
+              {prefix}
+              {getFileIcon(file)} {displayName}
+            </Text>
+          ) : (
+            <Text wrap="truncate-end">
+              {prefix}
+              {getFileIcon(file)} {displayName}
+            </Text>
+          )}
+        </Box>
+        <Box flexShrink={0}>
+          <Badge color={fileBadge.color}>{fileBadge.label}</Badge>
+        </Box>
       </Box>
     </Box>
   );

--- a/src/components/FileList/FileList.tsx
+++ b/src/components/FileList/FileList.tsx
@@ -302,6 +302,7 @@ const FileList = React.memo(function FileList({
                 <Box
                   key={`file-${item.groupIndex}-${item.fileIndex}`}
                   paddingLeft={2}
+                  width="100%"
                 >
                   <FileItem
                     file={file}


### PR DESCRIPTION

## Overview

### As-Is
- Long filenames would push the badge off-screen and break the layout during keyboard navigation
- Text would overflow without proper truncation when navigating with arrow keys

### To-Be
- Filenames are properly truncated with "..." ellipsis
- Badges stay fixed at the right edge regardless of filename length
- Layout remains stable during keyboard navigation

## Changes

### 1. Fix FileItem Layout Structure
- Add proper flex layout with `flexDirection="row"` and `gap={1}` for cleaner structure
- Set `flexShrink={1}` and `minWidth={0}` on the text container to enable proper text truncation
- This combination allows the CSS `text-overflow: ellipsis` to work correctly in React Ink

### 2. Ensure Proper Width Constraints
- Add `width="100%"` to FileItem wrapper in FileList component
- This ensures the FileItem takes full available width and can properly calculate truncation

## Technical Details

The key fix is adding `minWidth={0}` to the flex container. Without this, flexbox won't allow the text to shrink below its content width, preventing truncation. Combined with `flexShrink={1}`, this allows React Ink's `wrap="truncate-end"` to function correctly.