### PR TITLE
feat: add support for user settings file (~/.claude/settings.json)

### DIFF
--- a/src/_consts.ts
+++ b/src/_consts.ts
@@ -16,6 +16,7 @@ export const CLAUDE_FILE_PATTERNS = {
 export const FILE_SIZE_LIMITS = {
   MAX_CLAUDE_MD_SIZE: 1024 * 1024, // 1MB
   MAX_SLASH_COMMAND_SIZE: 512 * 1024, // 512KB
+  MAX_SETTINGS_SIZE: 256 * 1024, // 256KB
 } as const;
 
 // CLI output configuration

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 // Simple type alias
 export type ClaudeFilePath = string;
 
@@ -9,6 +11,15 @@ export const createClaudeFilePath = (path: string): ClaudeFilePath => {
   return path;
 };
 
+// Settings schema validation
+export const settingsSchema = z
+  .object({
+    theme: z.enum(['light', 'dark']).optional(),
+    enableAutoSave: z.boolean().optional(),
+    tabSize: z.number().optional(),
+  })
+  .passthrough();
+
 // Core types as defined in requirement
 export type ClaudeFileType =
   | 'claude-md'
@@ -19,6 +30,7 @@ export type ClaudeFileType =
   | 'user-agent'
   | 'settings-json'
   | 'settings-local-json'
+  | 'user-settings'
   | 'unknown';
 
 type _CommandInfo = {
@@ -29,9 +41,13 @@ type _CommandInfo = {
 
 export type ClaudeFileInfo = {
   readonly path: ClaudeFilePath;
+  readonly fileName?: string;
+  readonly dirPath?: string;
+  readonly fileType?: ClaudeFileType;
   readonly type: ClaudeFileType;
   readonly size: number;
   readonly lastModified: Date;
+  readonly content?: string;
   readonly commands: _CommandInfo[];
   readonly tags: string[];
 };

--- a/src/components/FileList/FileGroup.test.tsx
+++ b/src/components/FileList/FileGroup.test.tsx
@@ -33,6 +33,7 @@ if (import.meta.vitest) {
         'global-md': 'USER MEMORY',
         'settings-json': 'SETTINGS',
         'settings-local-json': 'LOCAL SETTINGS',
+        'user-settings': 'USER SETTINGS',
         unknown: 'OTHER',
       };
 

--- a/src/components/FileList/FileGroup.tsx
+++ b/src/components/FileList/FileGroup.tsx
@@ -21,6 +21,7 @@ const getGroupLabel = (type: ClaudeFileType): string => {
     .with('global-md', () => 'USER MEMORY')
     .with('settings-json', () => 'SETTINGS')
     .with('settings-local-json', () => 'LOCAL SETTINGS')
+    .with('user-settings', () => 'USER SETTINGS')
     .with('unknown', () => 'OTHER')
     .exhaustive();
 };
@@ -35,6 +36,7 @@ const getGroupColor = (type: ClaudeFileType): string => {
     .with('global-md', () => theme.fileTypes.globalMd)
     .with('settings-json', () => theme.fileTypes.settingsJson)
     .with('settings-local-json', () => theme.fileTypes.settingsLocalJson)
+    .with('user-settings', () => theme.fileTypes.settingsJson)
     .with('unknown', () => theme.fileTypes.unknown)
     .exhaustive();
 };

--- a/src/components/FileList/FileItem.tsx
+++ b/src/components/FileList/FileItem.tsx
@@ -52,6 +52,10 @@ export const FileItem = React.memo(function FileItem({
         color: theme.fileTypes.settingsLocalJson,
         label: 'LOCAL SETTINGS',
       }))
+      .with('user-settings', () => ({
+        color: theme.fileTypes.settingsJson,
+        label: 'USER SETTINGS',
+      }))
       .with('unknown', () => ({
         color: theme.fileTypes.unknown,
         label: 'FILE',
@@ -69,6 +73,7 @@ export const FileItem = React.memo(function FileItem({
       .with('global-md', () => '🧠')
       .with('settings-json', () => '⚙️')
       .with('settings-local-json', () => '🔧')
+      .with('user-settings', () => '👤')
       .with('unknown', () => '📄')
       .exhaustive();
   };

--- a/src/hooks/useFileNavigation.tsx
+++ b/src/hooks/useFileNavigation.tsx
@@ -111,13 +111,14 @@ export function useFileNavigation(
         // Create FileGroup array (in predefined order)
         const orderedTypes: ClaudeFileType[] = [
           'global-md',
+          'user-settings',
           'claude-md',
           'claude-local-md',
-          'project-agent',
-          'user-agent',
           'settings-json',
           'settings-local-json',
           'slash-command',
+          'project-agent',
+          'user-agent',
           'unknown',
         ];
         const groups: FileGroup[] = orderedTypes

--- a/src/test-fixture-helpers.ts
+++ b/src/test-fixture-helpers.ts
@@ -111,7 +111,7 @@ Test project for validating fs-fixture integration.
 /**
  * Default CLAUDE.local.md content for testing
  */
-const DEFAULT_CLAUDE_LOCAL_MD = `# CLAUDE.local.md
+export const DEFAULT_CLAUDE_LOCAL_MD = `# CLAUDE.local.md
 
 Local configuration overrides for this project.
 
@@ -124,7 +124,7 @@ Local configuration overrides for this project.
 /**
  * Default slash command content
  */
-const createSlashCommandContent = (
+export const createSlashCommandContent = (
   name: string,
   description = '',
 ) => `# /${name}

--- a/src/user-settings-scanner.ts
+++ b/src/user-settings-scanner.ts
@@ -1,0 +1,192 @@
+import type { Stats } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { FILE_SIZE_LIMITS } from './_consts.js';
+import type { ClaudeFileInfo, ClaudeFileType } from './_types.js';
+import { settingsSchema } from './_types.js';
+import { BaseFileScanner } from './base-file-scanner.js';
+
+class UserSettingsScanner extends BaseFileScanner<ClaudeFileInfo> {
+  protected readonly maxFileSize = FILE_SIZE_LIMITS.MAX_SETTINGS_SIZE;
+  protected readonly fileType = 'User settings';
+  protected readonly logger = {
+    debug: (message: string) => {
+      if (process.env.DEBUG) {
+        console.debug(message);
+      }
+    },
+  };
+  private readonly homedirFn: () => string;
+
+  constructor(homedirFn?: () => string) {
+    super();
+    this.homedirFn = homedirFn ?? homedir;
+  }
+
+  /**
+   * Get the path to the user settings file
+   */
+  getUserSettingsPath(): string {
+    return join(this.homedirFn(), '.claude', 'settings.json');
+  }
+
+  /**
+   * Scan for user settings file
+   */
+  async scan(): Promise<ClaudeFileInfo | null> {
+    const settingsPath = this.getUserSettingsPath();
+    return this.processFile(settingsPath);
+  }
+
+  protected async parseContent(
+    filePath: string,
+    content: string,
+    stats: Stats,
+  ): Promise<ClaudeFileInfo | null> {
+    try {
+      const settings = JSON.parse(content);
+      const validated = settingsSchema.parse(settings);
+
+      return {
+        path: filePath,
+        fileName: 'settings.json',
+        dirPath: join(this.homedirFn(), '.claude'),
+        type: 'user-settings' as ClaudeFileType,
+        fileType: 'user-settings' as ClaudeFileType,
+        size: stats.size,
+        lastModified: stats.mtime,
+        content: JSON.stringify(validated, null, 2),
+        commands: [],
+        tags: [],
+      };
+    } catch (error) {
+      // JSON parse error or validation error
+      this.logger.debug(
+        `Failed to parse user settings at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return null;
+    }
+  }
+}
+
+/**
+ * Convenience function to scan user settings
+ */
+export const scanUserSettings = async (
+  homedirFn?: () => string,
+): Promise<ClaudeFileInfo | null> => {
+  const scanner = new UserSettingsScanner(homedirFn);
+  return scanner.scan();
+};
+
+/**
+ * Export the scanner class for testing
+ */
+export { UserSettingsScanner };
+
+// InSource Tests
+if (import.meta.vitest != null) {
+  const { describe, test, expect, vi, afterEach } = import.meta.vitest;
+  const { createFixture } = await import('fs-fixture');
+
+  describe('UserSettingsScanner', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    test('should scan user settings file successfully', async () => {
+      await using fixture = await createFixture({
+        '.claude': {
+          'settings.json': JSON.stringify(
+            {
+              theme: 'dark',
+              enableAutoSave: true,
+              tabSize: 2,
+            },
+            null,
+            2,
+          ),
+        },
+      });
+
+      const scanner = new UserSettingsScanner(() => fixture.path);
+      const result = await scanner.scan();
+
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('user-settings');
+      expect(result?.fileName).toBe('settings.json');
+      expect(result?.dirPath).toBe(join(fixture.path, '.claude'));
+      expect(result?.path).toBe(join(fixture.path, '.claude', 'settings.json'));
+
+      // Verify content is valid JSON
+      if (result?.content) {
+        const parsed = JSON.parse(result.content);
+        expect(parsed.theme).toBe('dark');
+        expect(parsed.enableAutoSave).toBe(true);
+        expect(parsed.tabSize).toBe(2);
+      }
+    });
+
+    test('should return null when settings file does not exist', async () => {
+      await using fixture = await createFixture({});
+
+      const scanner = new UserSettingsScanner(() => fixture.path);
+      const result = await scanner.scan();
+
+      expect(result).toBeNull();
+    });
+
+    test('should return null for invalid JSON', async () => {
+      await using fixture = await createFixture({
+        '.claude': {
+          'settings.json': 'invalid json content',
+        },
+      });
+
+      const scanner = new UserSettingsScanner(() => fixture.path);
+      const result = await scanner.scan();
+
+      expect(result).toBeNull();
+    });
+
+    test('should return null for settings that fail validation', async () => {
+      await using fixture = await createFixture({
+        '.claude': {
+          'settings.json': JSON.stringify({
+            theme: 'invalid-theme', // Should fail validation
+            tabSize: 'not-a-number', // Should fail validation
+          }),
+        },
+      });
+
+      const scanner = new UserSettingsScanner(() => fixture.path);
+      const result = await scanner.scan();
+
+      expect(result).toBeNull();
+    });
+
+    test('getUserSettingsPath should return correct path', () => {
+      const mockHomedir = '/test/home';
+      const scanner = new UserSettingsScanner(() => mockHomedir);
+      const path = scanner.getUserSettingsPath();
+      expect(path).toBe(join(mockHomedir, '.claude', 'settings.json'));
+    });
+
+    test('scanUserSettings convenience function should work', async () => {
+      // Test the function exists and returns expected type
+      const result = await scanUserSettings();
+
+      // The result depends on whether the user has ~/.claude/settings.json
+      // We can only test that it returns null or a valid settings object
+      if (result !== null) {
+        expect(result.type).toBe('user-settings');
+        expect(result.fileName).toBe('settings.json');
+        expect(result.path).toContain('settings.json');
+        expect(result.commands).toEqual([]);
+        expect(result.tags).toEqual([]);
+      }
+      // Both null and valid object are acceptable results
+      expect(result === null || result?.type === 'user-settings').toBe(true);
+    });
+  });
+}


### PR DESCRIPTION

## Overview

### As-Is
- ccexp only supports Project Settings (`.claude/settings.json` and `.claude/settings.local.json`)
- User Settings (`~/.claude/settings.json`) are not displayed despite being part of Claude Code's settings hierarchy

### To-Be
- ccexp now supports User Settings files (`~/.claude/settings.json`)
- Complete support for Claude Code settings hierarchy as documented in [Anthropic's official documentation](https://docs.anthropic.com/en/docs/claude-code/settings#settings-files)

## Changes

### 1. Core Implementation
- Added new file type `user-settings` to `ClaudeFileType` enum
- Created `UserSettingsScanner` class extending `BaseFileScanner` to scan `~/.claude/settings.json`
- Updated file type detection logic in `detectClaudeFileType` to identify user settings files
- Integrated user settings scanner with the existing scanner system

### 2. UI Updates
- Updated `FileGroup` and `FileItem` components to display "USER SETTINGS" label
- Applied cyan color scheme (consistent with project settings files)
- Positioned user settings between "USER MEMORY" and "PROJECT" in the display order

## Implementation Details

The implementation uses `os.homedir()` for cross-platform home directory resolution and follows the existing scanner architecture pattern. The scanner gracefully handles cases where the user settings file doesn't exist.

## Related

- Closes #63
- Reference: https://docs.anthropic.com/en/docs/claude-code/settings#settings-files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and displaying user settings files located in the user's home directory.
  * User settings files now appear as a distinct group labeled "USER SETTINGS" in the file list, with a dedicated badge and icon.
  * User settings are included in settings scans and can be navigated and searched within the app.

* **Bug Fixes**
  * Improved file type detection to distinguish user settings files from other settings files.

* **Tests**
  * Introduced comprehensive tests for user settings detection, display, navigation, and validation.

* **Chores**
  * Exported additional helper functions and constants for improved test setup and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->